### PR TITLE
caire: remove sha

### DIFF
--- a/caire.rb
+++ b/caire.rb
@@ -4,7 +4,6 @@ class Caire < Formula
   desc "Content aware image resize library"
   homepage "https://github.com/esimov/caire"
   url "#{homepage}/releases/download/v#{CAIRE_VERSION}/caire-#{CAIRE_VERSION}-darwin-amd64.zip"
-  sha256 "e38ee949b1092c2b925dddd65d2584dd2eac2ddfb754942d1b854598f790ccf1"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
the download url can be for any version, whereas the sha was only for one